### PR TITLE
fix: pnpm v11 に非互換な preinstall スクリプトを削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "url": "git+https://github.com/book000/memo.git"
   },
   "scripts": {
-    "preinstall": "npx --yes only-allow pnpm",
     "lint": "textlint docs/",
     "fix": "textlint --fix docs/",
     "textlint": "textlint"


### PR DESCRIPTION
## 概要

pnpm v11 Renovate PR (#742) の CI 失敗を修正します。

## 問題の根本原因

pnpm v11 では lifecycle スクリプト実行時の環境変数の挙動が変更されました:

- pnpm v11 のソース ([exec/lifecycle/src/runLifecycleHook.ts](https://github.com/pnpm/pnpm/blob/v11.0.8/exec/lifecycle/src/runLifecycleHook.ts)) に `"npx only-allow pnpm"` のみを自動スキップするコードがある:
  ```
  if (m.scripts[stage] === 'npx only-allow pnpm' || !m.scripts[stage]) return false
  ```
- このプロジェクトでは `"npx --yes only-allow pnpm"` (`--yes` フラグ付き) を使用しているため、完全一致しない → スキップされずに実行される
- pnpm v11 では `npm_config_*` 環境変数の扱いが変わり ([PR #11116](https://github.com/pnpm/pnpm/pull/11116))、lifecycle スクリプト実行環境では既存の `npm_config_user_agent` が除去される
- `npx --yes` で `only-allow` が実行されると、`npx` (npm の一部) が `npm_config_user_agent` を `"npm/x.x.x ..."` として設定する
- `only-allow` が内部で使用する `which-pm-runs` が npm を検出し、"Use pnpm install" エラーが発生する

## 変更内容

`package.json` から `preinstall` スクリプト (`npx --yes only-allow pnpm`) を削除:

- `packageManager` フィールドで `pnpm@10.33.4` が指定されており、corepack によるパッケージマネージャの強制が可能
- pnpm v11 自体が `only-allow pnpm` スクリプトを特別扱いするほど、pnpm 強制の代替手段が整備されている
- Renovate PR (#742) と組み合わせることで pnpm v11 への移行が可能になる

## 検討した代替案

| 案 | 内容 | 不採用理由 |
|---|---|---|
| `--yes` を削除 | `npx only-allow pnpm` に変更 | pnpm v11 がスキップするので効果なし。また `only-allow` が未インストール環境での `npx` が対話的になる可能性 |
| `pnpm dlx only-allow pnpm` に変更 | pnpm dlx を使用 | pnpm v11 の `strictDepBuilds` により approve-builds プロンプトが出る可能性 |
| preinstall 削除 | **採用** | `packageManager` フィールドで代替可能。最もシンプル |

## 関連

- Renovate PR: #742 (pnpm v11 へのアップデート)
- book000/book000#108 (pnpm v11 関連 issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)