### PR TITLE
fix: テンプレートから pnpm approve-builds を削除

### DIFF
--- a/docs/programming/nodejs/template/Dockerfile
+++ b/docs/programming/nodejs/template/Dockerfile
@@ -11,7 +11,6 @@ RUN apk update && \
   echo "Asia/Tokyo" > /etc/timezone && \
   apk del tzdata && \
   npm install -g corepack@latest && \
-  pnpm approve-builds && \
   corepack enable
 
 WORKDIR /app
@@ -23,8 +22,7 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm fetch
 COPY package.json tsconfig.json ./
 COPY src src
 
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --offline && \
-  pnpm approve-builds
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --offline
 
 ENV NODE_ENV=production
 

--- a/docs/programming/nodejs/template/all.ps1
+++ b/docs/programming/nodejs/template/all.ps1
@@ -271,8 +271,6 @@ $postCreateCommands = @(
   "corepack install",
   # 依存関係をインストールする
   "pnpm install",
-  # approve-buildsを実行する
-  "pnpm approve-builds"
 )
 $postCreateCommand = $postCreateCommands -join " && "
 $devcontainerJson = @{


### PR DESCRIPTION
## 概要

Node.js テンプレートファイルから `pnpm approve-builds` を削除します。

## 変更ファイル

- `docs/programming/nodejs/template/Dockerfile` — 2 箇所削除
- `docs/programming/nodejs/template/all.ps1` — コメント含め削除

## 背景

pnpm v10 以降、lifecycle script を持つパッケージは `pnpm-workspace.yaml` の `allowBuilds` で事前に許可することで、`pnpm install` 実行時に自動的にスクリプトが実行されます。

関連: book000/book000#119

🤖 Generated with [Claude Code](https://claude.com/claude-code)