### PR TITLE
refactor(claude): カスタムコマンドをスキルに移行

### DIFF
--- a/.claude/skills/check-ai-writing/SKILL.md
+++ b/.claude/skills/check-ai-writing/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: check-ai-writing
+description: 記事の AI らしい表現をチェックし、textlint と手動確認で問題箇所を検出・修正する。記事執筆後または既存記事を大幅に編集した後に使用する。
+argument-hint: "[ファイルパス]"
+disable-model-invocation: true
+---
+
 # AI っぽさチェック
 
 記事の AI らしい表現をチェックし、問題があれば修正する。

--- a/.claude/skills/normalize-style/SKILL.md
+++ b/.claude/skills/normalize-style/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: normalize-style
+description: 記事本文のですます調をだ・である調に統一し、textlint で確認する。文体エラーを修正するときに使用する。
+argument-hint: "[ファイルパス]"
+disable-model-invocation: true
+---
+
 # 文体の統一
 
 記事本文のですます調をだ・である調に統一する。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,7 +264,7 @@ textlint の `preset-ai-writing` ルールによって自動検出できる項�
 
 新しい記事を書いた後、または既存記事を大幅に編集した後は、以下の工程を**必ず**実施すること。
 
-Claude Code を使用している場合は、`/check-ai-writing` コマンドでステップ 1・2 をまとめて実行できる。
+Claude Code を使用している場合は、`/check-ai-writing` スキルでステップ 1・2 をまとめて実行できる。
 
 ```
 /check-ai-writing docs/programming/foo.md


### PR DESCRIPTION
## 概要

Claude Code のカスタムコマンドを project skill に移行します。

## 変更内容

- `.claude/commands/check-ai-writing.md` を `.claude/skills/check-ai-writing/SKILL.md` に移行
- `.claude/commands/normalize-style.md` を `.claude/skills/normalize-style/SKILL.md` に移行
- 各 skill に `name`、`description`、`argument-hint`、`disable-model-invocation` を追加
- `CLAUDE.md` のカスタムコマンド表記をスキル表記に更新

## 確認

- `pnpm lint` 成功
- `git diff --check` 成功

Closes #819